### PR TITLE
Implement photo carousel in DetailsTab

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "react": "^0.14.8",
     "react-native": "^0.24.1",
+    "react-native-carousel": "^0.6.1",
     "react-native-simple-router": "^0.9.1",
     "react-redux": "^4.4.5",
     "redux": "^3.5.1",

--- a/src/containers/DetailsTab.js
+++ b/src/containers/DetailsTab.js
@@ -1,17 +1,42 @@
 import React, { Image, StyleSheet, Text, View } from 'react-native';
+import Carousel from 'react-native-carousel';
 
 export default class DetailsTab extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
   render() {
     const data = this.props.venueData;
+
+    const photoCollection = (
+      data.photos.map(photo =>
+        <Image
+          source={{uri: photo}}
+          style={styles.photo}
+          key={data.photos.indexOf(photo)}
+        />
+      )
+    );
 
     return (
       <View style={styles.container}>
         <Text style={styles.venue}>{data.venue}</Text>
-        <View style={styles.imagesContainer}>
-          <Image
-            source={{uri: data.photos}}
-            style={styles.photo}
-          />
+        <View style={styles.carouselContainer}>
+          <Carousel
+            width={340}
+            indicatorSize={30}
+            animate={false}
+            indicatorOffset={0}
+            indicatorColor={'darkseagreen'}
+            inactiveIndicatorColor={'ivory'}
+          >
+            {photoCollection}
+            <Image
+              source={{uri: data.seatingChart}}
+              style={styles.photo}
+            />
+          </Carousel>
         </View>
           <View style={styles.basicInfoContainer}>
             <View style={styles.timeContainer}>
@@ -32,9 +57,10 @@ const styles = StyleSheet.create({
   container: {
     padding: 20,
   },
-  imagesContainer: {
-    alignItems: 'center',
-    padding: 20,
+  carouselContainer: {
+    // alignItems: 'center',
+    marginTop: 20,
+    marginBottom: 20
   },
   photo: {
     width: 335,

--- a/src/reducers/tour.js
+++ b/src/reducers/tour.js
@@ -289,7 +289,7 @@ const initialState = {
       "doorTime": "6:30pm",
       "lotTime": "",
       "timeZone": "CT",
-      "photos": "http://www.levyrestaurants.com/images/xcel-energy-center/xcel_header.jpg",
+      "photos": ["http://www.levyrestaurants.com/images/xcel-energy-center/xcel_header.jpg", "http://finance-commerce.com/files/2014/04/Xcel6.jpg"],
       "seatingChart": "http://i.imgur.com/mzlkCcS.png",
     },
     {
@@ -307,7 +307,7 @@ const initialState = {
       "doorTime": "5:00pm",
       "lotTime": "",
       "timeZone": "CT",
-      "photos": "http://www.levyrestaurants.com/images/wrigley-field/wrigley-day-040512-sg-01-jpg.JPG",
+      "photos": ["http://www.levyrestaurants.com/images/wrigley-field/wrigley-day-040512-sg-01-jpg.JPG", "http://media.bizj.us/view/img/2740011/13645538345b53b1b7b62o*750xx5184-2922-0-0.jpg"],
       "seatingChart": "https://www.gotickets.com/cached/_images/maintainwidth/521x500/3289d6466a2cd8483042263f956c9f7d/wrigley-field-concert-4754.gif",
     },
     {
@@ -325,7 +325,7 @@ const initialState = {
       "doorTime": "6:00pm",
       "lotTime": "3:00pm",
       "timeZone": "CT",
-      "photos": "http://e994010f48279d85b5d7-a0bc3fbf1884fc0965506ae2b946e1cd.r57.cf2.rackcdn.com/herobox-images/_2000xAUTO_fit_center-center_80/Klipsch-Music-Center-v01-2001x1125.jpg",
+      "photos": ["http://e994010f48279d85b5d7-a0bc3fbf1884fc0965506ae2b946e1cd.r57.cf2.rackcdn.com/herobox-images/_2000xAUTO_fit_center-center_80/Klipsch-Music-Center-v01-2001x1125.jpg", "https://media-cdn.tripadvisor.com/media/photo-s/07/ac/21/c5/the-lawn-at-klipsch-music.jpg"],
       "seatingChart": "http://intl.ticketseating.com/maps/450w/2167-klipsch-music-center-end-stage.jpg",
     },
     {
@@ -343,7 +343,7 @@ const initialState = {
       "doorTime": "6:00pm",
       "lotTime": "",
       "timeZone": "ET",
-      "photos": "https://c7.staticflickr.com/5/4139/4821882342_d85847a22e_b.jpg",
+      "photos": ["https://c7.staticflickr.com/5/4139/4821882342_d85847a22e_b.jpg", "http://www.uwishunu.com/wp-content/uploads/2014/07/The-Philadelphia-Orchestra-The-Mann-680uw.jpg"],
       "seatingChart": "http://www.manncenter.org/sites/all/modules/mann_seating/images/Mann-Seating-Chart-2013.png",
     },
     {
@@ -361,7 +361,7 @@ const initialState = {
       "doorTime": "6:00pm",
       "lotTime": "4:30pm",
       "timeZone": "ET",
-      "photos": "http://onlinephishtour.com/wp-content/uploads/2011/04/spac10.jpg",
+      "photos": ["http://onlinephishtour.com/wp-content/uploads/2011/04/spac10.jpg", "http://discoversaratoga.org/wp-content/uploads/2015/01/spac-at-dusk-1200x800.jpg", "http://1.bp.blogspot.com/-XMSfF1FeSLo/UdrRwn-_HSI/AAAAAAAABbk/y1jFrntEiNY/s1600/1063822_10151448849506290_1834474559_o.jpg", "http://wac.450f.edgecastcdn.net/80450F/wgna.com/files/2012/02/SPAC-Flicker-User-Smantha-Decker-630x376.jpg"],
       "seatingChart": "http://luck.s3.amazonaws.com/venue/135.gif",
     },
     {
@@ -379,7 +379,7 @@ const initialState = {
       "doorTime": "6:00pm",
       "lotTime": "",
       "timeZone": "ET",
-      "photos": "http://static.bangordailynews.com/wp-content/uploads/2014/12/10038601_H14177325-600x405.jpeg",
+      "photos": ["http://static.bangordailynews.com/wp-content/uploads/2014/12/10038601_H14177325-600x405.jpeg", "http://www.roamingtherinks.com/photos/crossinsurancearenaoutside%20(700x393).jpg"],
       "seatingChart": "http://www.crossarenaportland.com/images/seatingcharts/full/ln42r.gif",
     },
     {
@@ -397,7 +397,7 @@ const initialState = {
       "doorTime": "6:00pm",
       "lotTime": "3:00pm",
       "timeZone": "ET",
-      "photos": "http://dmbalmanac.com/venuetdd/1373.jpg",
+      "photos": ["http://dmbalmanac.com/venuetdd/1373.jpg", "http://1.bp.blogspot.com/-441h6zBvc-0/U7QZsrLjBhI/AAAAAAAABp8/mAJVWidLS88/s1600/10421275_10100179212788344_8621021184398358444_n.jpg"],
       "seatingChart": "http://seatingchartview.com/wp-content/uploads/2013/07/Comcast-Center-Seating-Chart.gif",
     },
     {
@@ -415,7 +415,7 @@ const initialState = {
       "doorTime": "6:00pm",
       "lotTime": "4:30pm",
       "timeZone": "ET",
-      "photos": "http://i46.tinypic.com/2a5gn77.jpg",
+      "photos": ["http://i46.tinypic.com/2a5gn77.jpg", "https://rpw215.files.wordpress.com/2015/04/comcasttheatre.jpg"],
       "seatingChart": "http://seatingchartview.com/wp-content/uploads/2014/05/XFINITY-Theatre-Seating-Chart.png",
     },
     {
@@ -433,7 +433,7 @@ const initialState = {
       "doorTime": "6:00pm",
       "lotTime": "4:30pm",
       "timeZone": "ET",
-      "photos": "http://venuestoday.s3.amazonaws.com/img/lakeview600.jpg",
+      "photos": ["http://venuestoday.s3.amazonaws.com/img/lakeview600.jpg", "http://media.syracuse.com/news/photo/2015/08/03/amphitheaterjpg-d6eed28602a05d4f.jpg"],
       "seatingChart": "http://lakeviewamphitheatre.com/wp-content/uploads/2015/08/Seating8276889.jpg",
     },
     {
@@ -451,7 +451,7 @@ const initialState = {
       "doorTime": "5:30pm",
       "lotTime": "2:00pm",
       "timeZone": "PT",
-      "photos": "http://www.georgeamphitheatre.com/wp-content/uploads/2012/04/the-gorge.jpg",
+      "photos": ["http://www.georgeamphitheatre.com/wp-content/uploads/2012/04/the-gorge.jpg", "http://www.georgeamphitheatre.com/wp-content/uploads/2015/05/sasquatch-featured.png", "http://www.livenationpremiumseats.com/images/1440/620/400/image.jpg", "http://static1.squarespace.com/static/56971a1bfd5d08f1247677c4/56972f743b0be3f9ce884250/56972f798b38d4f1427f1d33/1452748669720/index--element91+(1).jpg"],
       "seatingChart": "http://d2o50i5c2dr30a.cloudfront.net/2658cbdb-7dd0-40b4-a798-e1a5014b4382.jpg",
     },
     {
@@ -469,7 +469,7 @@ const initialState = {
       "doorTime": "6:00pm",
       "lotTime": "",
       "timeZone": "PT",
-      "photos": "http://www.adaconcertvenues.com/wp-content/uploads/2015/12/Bill_Graham_Civic.jpg",
+      "photos": ["http://www.adaconcertvenues.com/wp-content/uploads/2015/12/Bill_Graham_Civic.jpg", "http://res.cloudinary.com/dostuff-media/image/upload//c_fill,g_faces,h_315,w_600/v1420677100/venue-16924.jpg", "http://i0.wp.com/livemusicblog.com/wp-content/uploads/2014/10/Phish-19.jpg?resize=395%2C264"],
       "seatingChart": "http://s1.ticketm.net/tm/en-us/tmimages/venue/maps/nca/39229s_a.gif",
     },
     {
@@ -487,7 +487,7 @@ const initialState = {
       "doorTime": "6:30pm",
       "lotTime": "",
       "timeZone": "PT",
-      "photos": "https://static.rukkus.com/venue/images/The_Forum-1399.jpg",
+      "photos": ["https://static.rukkus.com/venue/images/The_Forum-1399.jpg", "http://www.lapropoint.com/wp-content/uploads/2014/02/Bowl-RT-665x300.jpg"],
       "seatingChart": "https://www.barrystickets.com/losangeles/forum/charts/phish-forumseating.jpg",
     },
     {
@@ -505,7 +505,7 @@ const initialState = {
       "doorTime": "6:00pm",
       "lotTime": "",
       "timeZone": "PT",
-      "photos": "http://seatingchartview.com/wp-content/uploads/2014/03/Sleep-Train-Amphitheatre-Chula-Vista.jpg",
+      "photos": ["http://seatingchartview.com/wp-content/uploads/2014/03/Sleep-Train-Amphitheatre-Chula-Vista.jpg", "http://www.sacbee.com/entertainment/458c03/picture12051371/ALTERNATES/LANDSCAPE_1140/RB%20Sleep%20Train%20Stage.JPG"],
       "seatingChart": "http://s1.ticketm.net/ln/en-us/tmimages/venue/maps/wes/32420s.gif",
     },
     {
@@ -523,7 +523,7 @@ const initialState = {
       "doorTime": "",
       "lotTime": "",
       "timeZone": "ET",
-      "photos": "http://40.media.tumblr.com/23eb1f23ec6d3214dca8a6541066beb6/tumblr_mstanxfg6V1sdg8qgo3_1280.jpg",
+      "photos": ["http://40.media.tumblr.com/23eb1f23ec6d3214dca8a6541066beb6/tumblr_mstanxfg6V1sdg8qgo3_1280.jpg", "http://musichord.com/wp-content/uploads/2014/09/Triangle-Stage.jpg"],
       "seatingChart": "",
     },
     {
@@ -541,7 +541,7 @@ const initialState = {
       "doorTime": "6:00pm",
       "lotTime": "3:00pm",
       "timeZone": "MT",
-      "photos": "https://tackleandlines.files.wordpress.com/2013/01/564311_10150999996291290_407443937_n.jpg",
+      "photos": ["https://tackleandlines.files.wordpress.com/2013/01/564311_10150999996291290_407443937_n.jpg", "http://www.turnerconstruction.com/Files/ProjectImage?url=%2Fsites%2Fmarketingstories%2FMarketing%20Story%20Images%2Foriginal.d0ef2cb1-761d-4b23-8904-16029412f241.jpg&width=707&height=470&crop=True&jpegQuality=95"],
       "seatingChart": "http://www.cheapwholesaletickets.com/seatingcharts/dicks_sporting_goods_park-field_ga-seating-chart.gif",
     },
   ],


### PR DESCRIPTION
- Add `react-native-carousel` as dependency
- `photos` property in state.venues objects changed to array of url's
  - Allows for mapping of url's to unique `<Image />` instances in DetailsTab

Please `npm install`
