### PR TITLE
Fix tab flashing bug when backing out to ShowListView

### DIFF
--- a/src/containers/ShowDetailView.js
+++ b/src/containers/ShowDetailView.js
@@ -20,8 +20,7 @@ export class ShowDetailView extends React.Component {
     super(props);
   }
 
-  componentWillReceiveProps() {
-    // TODO: This changes the default tab back to 'details' when clicking the back button like we expect, but it flashes to 'details' before fully going back to ShowListView
+  componentWillUnmount() {
     if (this.props.tour.selectedTab !== 'details') {
       this.props.resetSelectedTab();
     }


### PR DESCRIPTION
- Move RESET_SELECTED_TAB execution to `componentWillUnmount` method
